### PR TITLE
Update INSTALL.rst

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,4 +1,3 @@
-
 Don't worry, Telemeta is easy to setup as any other Django app !
 
 -----------------
@@ -118,7 +117,7 @@ Fast testing (sandbox)
 If you just want to test Telemeta just now, a sandbox is available in the example/ directory::
 
     cd example/sandbox_sqlite
-    ./manage.py syncdb
+    ./manage.py syncdb --migrate
     ./manage.py runserver 9000
 
 Now browse http://localhost:9000


### PR DESCRIPTION
add --migrate too syncdb command othrwize error like so
`cd /Telemeta/example/sandbox_sqlite`
`./manage.py syncdb`

```
Syncing...
Creating tables ...
Installing custom SQL ...
Installing indexes ...
No fixtures found.

Synced:
 > django.contrib.auth
 > django.contrib.contenttypes
 > django.contrib.sessions
 > django.contrib.sites
 > django.contrib.messages
 > django.contrib.admin
 > django.contrib.staticfiles
 > django_extensions
 > south
 > sorl.thumbnail

Not synced (use migrations):
 - telemeta
```
