### PR TITLE
Fix process() error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,8 @@ setup(
         'django-environ',
         'redis',
         'Werkzeug',
-        'django-dirtyfields'
+        'django-dirtyfields',
+        'sqlparse==0.1.19'
     ],
   tests_require=['pytest-django', 'pytest-cov', 'factory-boy'],
   # Provide a test command through django-setuptest


### PR DESCRIPTION
Set version of sqlparse to 0.1.19

Used for debug_toolbar. Debug_toolbar with last version of debug_toolbar V1.3.2 doesn't work because of update sqlparse recently